### PR TITLE
Move java.net rule helper class to agent to avoid classloading issue …

### DIFF
--- a/opentracing-agent/src/main/java/io/opentracing/contrib/agent/javanet/propagation/HttpURLConnectionInjectAdapter.java
+++ b/opentracing-agent/src/main/java/io/opentracing/contrib/agent/javanet/propagation/HttpURLConnectionInjectAdapter.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.opentracing.contrib.agent.jnet.propagation;
+package io.opentracing.contrib.agent.javanet.propagation;
 
 import java.net.HttpURLConnection;
 import java.util.Iterator;

--- a/rules/java-net/src/main/resources/otarules.btm
+++ b/rules/java-net/src/main/resources/otarules.btm
@@ -13,7 +13,7 @@ DO
     .asChildOf(currentSpan())
     .start());
   getTracer().inject(retrieveSpan($0).context(), io.opentracing.propagation.Format$Builtin.HTTP_HEADERS,
-    new io.opentracing.contrib.agent.jnet.propagation.HttpURLConnectionInjectAdapter($0));
+    new io.opentracing.contrib.agent.javanet.propagation.HttpURLConnectionInjectAdapter($0));
 ENDRULE
 
 RULE java-net: Java HttpUrlConnection getResponseCode entry
@@ -30,7 +30,7 @@ DO
     .asChildOf(currentSpan())
     .start());
   getTracer().inject(retrieveSpan($0).context(), io.opentracing.propagation.Format$Builtin.HTTP_HEADERS,
-     new io.opentracing.contrib.agent.jnet.propagation.HttpURLConnectionInjectAdapter($0));
+     new io.opentracing.contrib.agent.javanet.propagation.HttpURLConnectionInjectAdapter($0));
 ENDRULE
 
 RULE java-net: Java HttpUrlConnection getInputStream entry
@@ -47,7 +47,7 @@ DO
     .asChildOf(currentSpan())
     .start());
   getTracer().inject(retrieveSpan($0).context(), io.opentracing.propagation.Format$Builtin.HTTP_HEADERS,
-    new io.opentracing.contrib.agent.jnet.propagation.HttpURLConnectionInjectAdapter($0));
+    new io.opentracing.contrib.agent.javanet.propagation.HttpURLConnectionInjectAdapter($0));
 ENDRULE
 
 RULE java-net: Java HttpUrlConnection getOutputStream entry
@@ -64,7 +64,7 @@ DO
     .asChildOf(currentSpan())
     .start());
   getTracer().inject(retrieveSpan($0).context(), io.opentracing.propagation.Format$Builtin.HTTP_HEADERS,
-    new io.opentracing.contrib.agent.jnet.propagation.HttpURLConnectionInjectAdapter($0));
+    new io.opentracing.contrib.agent.javanet.propagation.HttpURLConnectionInjectAdapter($0));
 ENDRULE
 
 # This rule catches connection refused exceptions


### PR DESCRIPTION
…when java.net rule used as a nested dependency