### PR TITLE
Prevent instrumentation of the tracer setup by default

### DIFF
--- a/opentracing-agent/pom.xml
+++ b/opentracing-agent/pom.xml
@@ -44,6 +44,14 @@
       <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+      <type>test-jar</type>
+      <version>${version.io.opentracing}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/opentracing-agent/src/test/java/io/opentracing/contrib/agent/DummyTracer.java
+++ b/opentracing-agent/src/test/java/io/opentracing/contrib/agent/DummyTracer.java
@@ -21,21 +21,28 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
+import org.jboss.byteman.rule.Rule;
 
 /**
  * This dummy tracer only exists to be service loaded for test purposes.
  *
  */
 public class DummyTracer implements Tracer {
+    /**
+     * Whether or not the tracer was initialized with triggering enabled.
+     */
+    private boolean triggeringEnabled;
 
     public DummyTracer() {
+        triggeringEnabled = Rule.isTriggeringEnabled();
     }
 
     @Override
     public SpanBuilder buildSpan(String operationName) {
-        // For test purposes, simply through a specific exception to indicate that
-        // this tracer was called.
-        throw new DummyCalled();
+        // For test purposes, simply throw a specific exception to indicate that
+        // this tracer was initialized, and whether instrumentation was enabled
+        // when it was created.
+        throw new DummyCalled(triggeringEnabled);
     }
 
     @Override
@@ -49,6 +56,12 @@ public class DummyTracer implements Tracer {
 
     public static class DummyCalled extends RuntimeException {
         private static final long serialVersionUID = 1L;
+
+        public boolean triggeringEnabled;
+
+        private DummyCalled(boolean triggeringEnabled) {
+            this.triggeringEnabled = triggeringEnabled;
+        }
     }
 
     @Override


### PR DESCRIPTION
For example, the Jaeger tracer uses OkHttp in its HTTP sender, so if
instrumenting a project with that library and letting the TracerResolver
initialize the tracer, an error will occur since the synchronization
doesn't apply to recursive invocations of the `OpenTracingHelper.initTracer`
method on the same thread.

This can be enabled with a special system property if so desired.

Suggestions for how to automatically test this are welcome.  I tried a few things but it was difficult to figure out a robust way to test this due to how the TracerResolver only resolves and instantiates the tracer once.