### PR TITLE
Adds java-concurrent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <version.io.opentracing.contrib.tracerresolver>0.1.5</version.io.opentracing.contrib.tracerresolver>
     <version.io.opentracing.contrib.web-servlet-filter>0.1.1</version.io.opentracing.contrib.web-servlet-filter>
     <version.io.opentracing.contrib.okhttp3>0.1.0</version.io.opentracing.contrib.okhttp3>
-    <version.io.opentracing.contrib.concurrent>0.2.1-SNAPSHOT</version.io.opentracing.contrib.concurrent>
+    <version.io.opentracing.contrib.concurrent>0.2.0</version.io.opentracing.contrib.concurrent>
     <version.junit>4.12</version.junit>
     <version.org.apache.tomcat.embed>8.0.41</version.org.apache.tomcat.embed>
     <version.org.eclipse.jetty>9.4.1.v20170120</version.org.eclipse.jetty>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <version.io.opentracing.contrib.tracerresolver>0.1.5</version.io.opentracing.contrib.tracerresolver>
     <version.io.opentracing.contrib.web-servlet-filter>0.1.1</version.io.opentracing.contrib.web-servlet-filter>
     <version.io.opentracing.contrib.okhttp3>0.1.0</version.io.opentracing.contrib.okhttp3>
+    <version.io.opentracing.contrib.concurrent>0.2.1-SNAPSHOT</version.io.opentracing.contrib.concurrent>
     <version.junit>4.12</version.junit>
     <version.org.apache.tomcat.embed>8.0.41</version.org.apache.tomcat.embed>
     <version.org.eclipse.jetty>9.4.1.v20170120</version.org.eclipse.jetty>
@@ -100,6 +101,11 @@
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-okhttp3</artifactId>
         <version>${version.io.opentracing.contrib.okhttp3}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-concurrent</artifactId>
+        <version>${version.io.opentracing.contrib.concurrent}</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing.contrib</groupId>

--- a/rules/java-concurrent/pom.xml
+++ b/rules/java-concurrent/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>opentracing-agent-rules-parent</artifactId>
+        <groupId>io.opentracing.contrib</groupId>
+        <version>0.3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opentracing-agent-rules-java-concurrent</artifactId>
+
+    <properties>
+        <opentracing-agent.lib>${project.build.directory}/lib</opentracing-agent.lib>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-agent</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-agent-itests</artifactId>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-concurrent</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>get-agent</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentracing.contrib</groupId>
+                                    <artifactId>opentracing-agent</artifactId>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${opentracing-agent.lib}</outputDirectory>
+                                    <destFileName>opentracing-agent.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        -javaagent:${opentracing-agent.lib}/opentracing-agent.jar
+                        -Dorg.jboss.byteman.verbose
+                    </argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*ITest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>final-verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/rules/java-concurrent/src/main/resources/otarules.btm
+++ b/rules/java-concurrent/src/main/resources/otarules.btm
@@ -1,0 +1,58 @@
+##################################################################################
+# java-concurrent Rule Set
+#
+# This rule set will intercept calls to all methods specified by
+# java.util.concurrent.Executor and subinterfaces in java.util.concurrent.
+#
+# The rule set assumes that all calls to ExecutorService's methods eventually
+# call Executor.execute(Runnable)
+#
+# TODO: Consider generating rule set from script.
+# See: https://stackoverflow.com/a/32763032/4814697
+
+HELPER io.opentracing.contrib.agent.OpenTracingHelper
+
+RULE Executor.execute
+INTERFACE ^java.util.concurrent.Executor
+METHOD execute
+AT ENTRY
+IF getTracer().activeSpan() != null
+DO
+   $1 = new io.opentracing.contrib.concurrent.TracedRunnable($1, getTracer());
+ENDRULE
+
+RULE ScheduledExecutorService.schedule(Runnable)
+INTERFACE ^java.util.concurrent.ScheduledExecutorService
+METHOD schedule(java.lang.Runnable,long,java.util.concurrent.TimeUnit)
+AT ENTRY
+IF getTracer().activeSpan() != null
+DO
+   $1 = new io.opentracing.contrib.concurrent.TracedRunnable($1, getTracer());
+ENDRULE
+
+RULE ScheduledExecutorService.schedule(Callable)
+INTERFACE ^java.util.concurrent.ScheduledExecutorService
+METHOD schedule(java.util.concurrent.Callable,long,java.util.concurrent.TimeUnit)
+AT ENTRY
+IF getTracer().activeSpan() != null
+DO
+   $1 = new io.opentracing.contrib.concurrent.TracedCallable($1, getTracer());
+ENDRULE
+
+RULE ScheduledExecutorService.scheduleAtFixedRate
+INTERFACE ^java.util.concurrent.ScheduledExecutorService
+METHOD scheduleAtFixedRate
+AT ENTRY
+IF getTracer().activeSpan() != null
+DO
+   $1 = new io.opentracing.contrib.concurrent.TracedRunnable($1, getTracer());
+ENDRULE
+
+RULE ScheduledExecutorService.scheduleWithFixedDelay
+INTERFACE ^java.util.concurrent.ScheduledExecutorService
+METHOD scheduleWithFixedDelay
+AT ENTRY
+IF getTracer().activeSpan() != null
+DO
+   $1 = new io.opentracing.contrib.concurrent.TracedRunnable($1, getTracer());
+ENDRULE

--- a/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/AbstractConcurrentTest.java
+++ b/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/AbstractConcurrentTest.java
@@ -1,0 +1,79 @@
+package io.opentracing.contrib.agent.concurrent;
+
+import io.opentracing.contrib.agent.common.OTAgentTestBase;
+import io.opentracing.mock.MockSpan;
+import org.junit.Before;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Pavol Loffay
+ * @author Jose Montoya
+ */
+public abstract class AbstractConcurrentTest extends OTAgentTestBase {
+
+	protected CountDownLatch countDownLatch = new CountDownLatch(0);
+
+	@Before
+	@Override
+	public void init() {
+		super.init();
+		countDownLatch = new CountDownLatch(1);
+	}
+
+	protected void assertParentSpan(MockSpan parent) {
+		for (MockSpan child : getTracer().finishedSpans()) {
+			if (child == parent) {
+				continue;
+			}
+
+			if (parent == null) {
+				assertEquals(0, child.parentId());
+			} else {
+				assertEquals(parent.context().traceId(), child.context().traceId());
+				assertEquals(parent.context().spanId(), child.parentId());
+			}
+		}
+	}
+
+	protected Thread createThread(Runnable runnable) {
+		Thread thread = new Thread(runnable);
+		return thread;
+	}
+
+	protected <V> Thread createThread(FutureTask<V> futureTask) {
+		Thread thread = new Thread(futureTask);
+		return thread;
+	}
+
+	class TestRunnable implements Runnable {
+		@Override
+		public void run() {
+			try {
+				getTracer().buildSpan("childRunnable")
+						.startActive(true)
+						.close();
+			} finally {
+				countDownLatch.countDown();
+			}
+		}
+	}
+
+	class TestCallable implements Callable<Void> {
+		@Override
+		public Void call() throws Exception {
+			try {
+				getTracer().buildSpan("childCallable")
+						.startActive(true)
+						.close();
+			} finally {
+				countDownLatch.countDown();
+			}
+			return null;
+		}
+	}
+}

--- a/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorITest.java
+++ b/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorITest.java
@@ -1,0 +1,30 @@
+package io.opentracing.contrib.agent.concurrent;
+
+import io.opentracing.mock.MockSpan;
+import org.junit.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Pavol Loffay
+ * @author Jose Montoya
+ */
+public class ExecutorITest extends AbstractConcurrentTest {
+
+	@Test
+	public void testExecute() throws InterruptedException {
+		Executor executor = Executors.newFixedThreadPool(10);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		executor.execute(new TestRunnable());
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(1, getTracer().finishedSpans().size());
+
+	}
+}

--- a/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorServiceITest.java
+++ b/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorServiceITest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 public class ExecutorServiceITest extends AbstractConcurrentTest {
 	private static final int NUMBER_OF_THREADS = 4;
 
-
 	@Test
 	public void testExecuteRunnable() throws InterruptedException {
 		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);

--- a/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorServiceITest.java
+++ b/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ExecutorServiceITest.java
@@ -1,0 +1,124 @@
+package io.opentracing.contrib.agent.concurrent;
+
+import io.opentracing.mock.MockSpan;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Pavol Loffay
+ * @author Jose Montoya
+ */
+public class ExecutorServiceITest extends AbstractConcurrentTest {
+	private static final int NUMBER_OF_THREADS = 4;
+
+
+	@Test
+	public void testExecuteRunnable() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		executorService.execute(new TestRunnable());
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(1, getTracer().finishedSpans().size());
+	}
+
+	@Test
+	public void testSubmitRunnable() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		executorService.submit(new TestRunnable());
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(1, getTracer().finishedSpans().size());
+	}
+
+	@Test
+	public void testSubmitRunnableTyped() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		executorService.submit(new TestRunnable(), new Object());
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(1, getTracer().finishedSpans().size());
+	}
+
+	@Test
+	public void testSubmitCallable() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		executorService.submit(new TestCallable());
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(1, getTracer().finishedSpans().size());
+	}
+
+	@Test
+	public void testInvokeAll() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		countDownLatch = new CountDownLatch(2);
+		executorService.invokeAll(Arrays.asList(new TestCallable(), new TestCallable()));
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(2, getTracer().finishedSpans().size());
+	}
+
+	@Test
+	public void testInvokeAllTimeUnit() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		countDownLatch = new CountDownLatch(2);
+		executorService.invokeAll(Arrays.asList(new TestCallable(), new TestCallable()), 1, TimeUnit.SECONDS);
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(2, getTracer().finishedSpans().size());
+	}
+
+	@Test
+	public void testInvokeAnyTimeUnit() throws InterruptedException, ExecutionException, TimeoutException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		executorService.invokeAny(Arrays.asList(new TestCallable()), 1, TimeUnit.SECONDS);
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(1, getTracer().finishedSpans().size());
+	}
+
+	@Test
+	public void testInvokeAny() throws InterruptedException, ExecutionException {
+		ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo").startManual();
+		getTracer().scopeManager().activate(parentSpan, true);
+		executorService.invokeAny(Arrays.asList(new TestCallable()));
+
+		countDownLatch.await();
+		assertParentSpan(parentSpan);
+		assertEquals(1, getTracer().finishedSpans().size());
+	}
+}

--- a/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ScheduledExecutorServiceITest.java
+++ b/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ScheduledExecutorServiceITest.java
@@ -1,0 +1,76 @@
+package io.opentracing.contrib.agent.concurrent;
+
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Pavol Loffay
+ * @author Jose Montoya
+ */
+public class ScheduledExecutorServiceITest extends AbstractConcurrentTest {
+	private static final int NUMBER_OF_THREADS = 4;
+
+
+	@Test
+	public void scheduleRunnableTest() throws InterruptedException {
+		ScheduledExecutorService executorService = Executors.newScheduledThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo-1").start();
+		try (Scope scope = getTracer().scopeManager().activate(parentSpan, true)) {
+			executorService.schedule(new TestRunnable(), 300, TimeUnit.MILLISECONDS);
+			countDownLatch.await();
+			assertParentSpan(parentSpan);
+			assertEquals(1, getTracer().finishedSpans().size());
+		}
+
+	}
+
+	@Test
+	public void scheduleCallableTest() throws InterruptedException {
+		ScheduledExecutorService executorService = Executors.newScheduledThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo-2").start();
+		try (Scope scope = getTracer().scopeManager().activate(parentSpan, true)) {
+			executorService.schedule(new TestCallable(), 300, TimeUnit.MILLISECONDS);
+			countDownLatch.await();
+			assertParentSpan(parentSpan);
+			assertEquals(1, getTracer().finishedSpans().size());
+		}
+	}
+
+	@Test
+	public void scheduleAtFixedRateTest() throws InterruptedException {
+		countDownLatch = new CountDownLatch(2);
+		ScheduledExecutorService executorService = Executors.newScheduledThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo-3").start();
+		try (Scope scope = getTracer().scopeManager().activate(parentSpan, true)) {
+			executorService.scheduleAtFixedRate(new TestRunnable(), 0, 300, TimeUnit.MILLISECONDS);
+
+			countDownLatch.await();
+			executorService.shutdown();
+			assertParentSpan(parentSpan);
+			assertEquals(2, getTracer().finishedSpans().size());
+		}
+	}
+
+	@Test
+	public void scheduleWithFixedDelayTest() throws InterruptedException {
+		countDownLatch = new CountDownLatch(2);
+		ScheduledExecutorService executorService = Executors.newScheduledThreadPool(NUMBER_OF_THREADS);
+
+		MockSpan parentSpan = getTracer().buildSpan("foo-4").start();
+		try (Scope scope = getTracer().scopeManager().activate(parentSpan, true)) {
+			executorService.scheduleWithFixedDelay(new TestRunnable(), 0, 300, TimeUnit.MILLISECONDS);
+			countDownLatch.await();
+			executorService.shutdown();
+			assertParentSpan(parentSpan);
+			assertEquals(2, getTracer().finishedSpans().size());
+		}
+	}
+}

--- a/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ScheduledExecutorServiceITest.java
+++ b/rules/java-concurrent/src/test/java/io/opentracing/contrib/agent/concurrent/ScheduledExecutorServiceITest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 public class ScheduledExecutorServiceITest extends AbstractConcurrentTest {
 	private static final int NUMBER_OF_THREADS = 4;
 
-
 	@Test
 	public void scheduleRunnableTest() throws InterruptedException {
 		ScheduledExecutorService executorService = Executors.newScheduledThreadPool(NUMBER_OF_THREADS);

--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -13,6 +13,7 @@
   <modules>
     <module>java-okhttp</module>
     <module>java-web-servlet-filter</module>
+    <module>java-concurrent</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Adds byteman rules for intercepting calls to java.util.concurrent.Executor interface and subinterfaces and proxying to appropriate TracedExecutors.

Is dependent on https://github.com/opentracing-contrib/java-concurrent/pull/11