### PR TITLE
Adds java-jdbc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <version.io.opentracing.contrib.web-servlet-filter>0.1.1</version.io.opentracing.contrib.web-servlet-filter>
     <version.io.opentracing.contrib.okhttp3>0.1.0</version.io.opentracing.contrib.okhttp3>
     <version.io.opentracing.contrib.concurrent>0.2.0</version.io.opentracing.contrib.concurrent>
+    <version.io.opentracing.contrib.jdbc>0.0.8</version.io.opentracing.contrib.jdbc>
     <version.junit>4.12</version.junit>
     <version.org.apache.tomcat.embed>8.0.41</version.org.apache.tomcat.embed>
     <version.org.eclipse.jetty>9.4.1.v20170120</version.org.eclipse.jetty>
@@ -63,6 +64,7 @@
     <version.maven-javadoc-plugin>2.10.4</version.maven-javadoc-plugin>
     <version.io.takari-maven>0.3.4</version.io.takari-maven>
     <version.io.zikin.centralsync-maven-plugin>0.1.0</version.io.zikin.centralsync-maven-plugin>
+    <version.com.h2database.h2>1.4.197</version.com.h2database.h2>
   </properties>
 
   <dependencyManagement>
@@ -106,6 +108,16 @@
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-concurrent</artifactId>
         <version>${version.io.opentracing.contrib.concurrent}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-jdbc</artifactId>
+        <version>${version.io.opentracing.contrib.jdbc}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${version.com.h2database.h2}</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing.contrib</groupId>

--- a/rules/java-jdbc/pom.xml
+++ b/rules/java-jdbc/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>opentracing-agent-rules-parent</artifactId>
+        <groupId>io.opentracing.contrib</groupId>
+        <version>0.3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opentracing-agent-rules-java-jdbc</artifactId>
+
+    <properties>
+        <opentracing-agent.lib>${project.build.directory}/lib</opentracing-agent.lib>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-agent</artifactId>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-agent-itests</artifactId>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>get-agent</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentracing.contrib</groupId>
+                                    <artifactId>opentracing-agent</artifactId>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${opentracing-agent.lib}</outputDirectory>
+                                    <destFileName>opentracing-agent.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        -javaagent:${opentracing-agent.lib}/opentracing-agent.jar
+                        -Dorg.jboss.byteman.verbose
+                    </argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>run-integration-tests</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*ITest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>final-verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/rules/java-jdbc/src/main/resources/otarules.btm
+++ b/rules/java-jdbc/src/main/resources/otarules.btm
@@ -1,0 +1,15 @@
+RULE java-jdbc wrap Driver Connection
+INTERFACE ^java.sql.Driver
+METHOD java.sql.Connection connect(String, java.util.Properties)
+HELPER io.opentracing.contrib.agent.OpenTracingHelper
+AT EXIT
+IF NOT $! == null
+    AND NOT callerEquals("io.opentracing.contrib.jdbc.TracingDriver.connect", true, true, 0, 1)
+DO
+    $! = new io.opentracing.contrib.jdbc.TracingConnection($!,
+         $!.getMetaData().getURL().split(":")[1],
+         $!.getMetaData().getUserName(),
+         true,
+         java.util.Collections.emptySet(),
+         getTracer())
+ENDRULE

--- a/rules/java-jdbc/src/test/java/io/opentracing/contrib/agent/jdbc/JdbcITest.java
+++ b/rules/java-jdbc/src/test/java/io/opentracing/contrib/agent/jdbc/JdbcITest.java
@@ -1,0 +1,40 @@
+package io.opentracing.contrib.agent.jdbc;
+
+/**
+ * Created by jam01 on 9/13/18.
+ */
+
+import io.opentracing.Scope;
+import io.opentracing.contrib.agent.common.OTAgentTestBase;
+import io.opentracing.mock.MockSpan;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author malafeev
+ * @author Jose Montoya
+ */
+public class JdbcITest extends OTAgentTestBase {
+
+	@Test
+	public void test() throws Exception {
+		try (Scope ignored = getTracer().buildSpan("jdbc-test").startActive(true)) {
+
+			Connection connection = DriverManager.getConnection("jdbc:h2:mem:jdbc");
+			Statement statement = connection.createStatement();
+			statement.executeUpdate("CREATE TABLE employer (id INTEGER)");
+			connection.close();
+
+			List<MockSpan> spans = getTracer().finishedSpans();
+			assertEquals(1, spans.size());
+		}
+
+	}
+
+}

--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -14,6 +14,7 @@
     <module>java-okhttp</module>
     <module>java-web-servlet-filter</module>
     <module>java-concurrent</module>
+    <module>java-jdbc</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Adds byteman rules for intercepting calls to java.sql.Driver.connect and wraps the result in a TracingConnection from java-jdbc contrib project. Includes a simpler jdbc h2 test from that same project.